### PR TITLE
Fixed examples used to get file paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ $ret.items.client_id | get-unique
 $ret.items.client_id | Get-GRRComputerNameFromClientId -Credential $cred | get-unique
 
 # Get unique file paths from a file finder hunt
-($ret.items.payload.stat_entry.pathspec.path).substring(31) | sort -u
+$ret.items.payload.stat_entry.pathspec.path | sort -u
 
 # Remove the label if you don't use it anymore
 $clients | Remove-GRRLabel -SearchString INC01 -$Credential $creds

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ $ret.items.client_id | get-unique
 $ret.items.client_id | Get-GRRComputerNameFromClientId -Credential $cred | get-unique
 
 # Get unique file paths from a file finder hunt
-($ret.items.payload.stat_entry.aff4path).substring(31) | sort -u
+($ret.items.payload.stat_entry.pathspec.path).substring(31) | sort -u
 
 # Remove the label if you don't use it anymore
 $clients | Remove-GRRLabel -SearchString INC01 -$Credential $creds

--- a/docs/Get-GRRHuntResult.md
+++ b/docs/Get-GRRHuntResult.md
@@ -24,7 +24,7 @@ Get hunt results for a specific hunt.
 ### Example 1
 ```
 PS C:\> $res = Get-GRRHuntResult -HuntId H:AAAAAAAA -Credential $creds
-PS C:\> ($res.items.payload.stat_entry.aff4path).substring(31) | sort -u
+PS C:\> ($res.items.payload.stat_entry.pathspec.path).substring(31) | sort -u
 PS C:\> $res.items.client_id | sort -u
 ```
 

--- a/docs/Get-GRRHuntResult.md
+++ b/docs/Get-GRRHuntResult.md
@@ -24,7 +24,7 @@ Get hunt results for a specific hunt.
 ### Example 1
 ```
 PS C:\> $res = Get-GRRHuntResult -HuntId H:AAAAAAAA -Credential $creds
-PS C:\> ($res.items.payload.stat_entry.pathspec.path).substring(31) | sort -u
+PS C:\> $res.items.payload.stat_entry.pathspec.path | sort -u
 PS C:\> $res.items.client_id | sort -u
 ```
 

--- a/en-us/PowerGRR-help.xml
+++ b/en-us/PowerGRR-help.xml
@@ -3233,7 +3233,7 @@ False</dev:code>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
         <dev:code>PS C:\&gt; $res = Get-GRRHuntResult -HuntId H:AAAAAAAA -Credential $creds
-PS C:\&gt; ($res.items.payload.stat_entry.pathspec.path).substring(31) | sort -u
+PS C:\&gt; $res.items.payload.stat_entry.pathspec.path | sort -u
 PS C:\&gt; $res.items.client_id | sort -u</dev:code>
         <dev:remarks>
           <maml:para>Get hunt results based on a hunt id. Display all the unique file paths which were found with a file finder hunt. Only display the unique GRR client id's. then you can use `Get-GRRComputerNameByClientId` to display only the computer names.</maml:para>

--- a/en-us/PowerGRR-help.xml
+++ b/en-us/PowerGRR-help.xml
@@ -3233,7 +3233,7 @@ False</dev:code>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
         <dev:code>PS C:\&gt; $res = Get-GRRHuntResult -HuntId H:AAAAAAAA -Credential $creds
-PS C:\&gt; ($res.items.payload.stat_entry.aff4path).substring(31) | sort -u
+PS C:\&gt; ($res.items.payload.stat_entry.pathspec.path).substring(31) | sort -u
 PS C:\&gt; $res.items.client_id | sort -u</dev:code>
         <dev:remarks>
           <maml:para>Get hunt results based on a hunt id. Display all the unique file paths which were found with a file finder hunt. Only display the unique GRR client id's. then you can use `Get-GRRComputerNameByClientId` to display only the computer names.</maml:para>


### PR DESCRIPTION
The examples in the documentation/Readme used to refer to file paths with property `aff4path` in a GRR hunt do not work currently. Replaced them with property `pathspec.path`.