### PR TITLE
Add pathtype parameter to FileFinder flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/swisscom/powergrr/compare/v0.11.0...master)
 
-<!--
 ### Added
+
+* Add pathtype parameter to FileFinder which allows using TSK or NTFS to
+  access locked files, used for e.g. registry files or $MFT on Windows.
+
+<!--
 ### Changed
 ### Fixed
 ### Security

--- a/PowerGRR.psm1
+++ b/PowerGRR.psm1
@@ -1180,6 +1180,12 @@ function Get-FlowArgs()
     {
         $PluginArguments = '{"paths":["'+$($Parameters['Path']-join'","')+'"]'
 
+	if ($($Parameters['Pathtype']))
+	{
+		$Pathtype = $( $Parameters['Pathtype'])
+		$PluginArguments += ',"pathtype":"'+$($Parameters['Pathtype'])+'"'
+	}
+
         if ($($Parameters['Mode']))
         {
             $RegexMode = $( $Parameters['Mode'])
@@ -1323,6 +1329,7 @@ function Get-DynamicFlowParam()
     if ($Params.containskey('flow') -and $Params.Flow -eq "FileFinder")
     {
         New-DynamicParam -Name Path -mandatory -DPDictionary $Dictionary -Type String[]
+        New-DynamicParam -Name Pathtype -ValidateSet "OS(default)",TSK,NTFS,REGISTRY -DPDictionary $Dictionary
         New-DynamicParam -Name ActionType -mandatory -ValidateSet Hash,Download -DPDictionary $Dictionary
         New-DynamicParam -Name ConditionType -ValidateSet Regex,Literal -DPDictionary $Dictionary
         New-DynamicParam -Name Mode -ValidateSet ALL_HITS,FIRST_HIT -DPDictionary $Dictionary


### PR DESCRIPTION
* The pathtype parameter allows using TSK (deprecated) or NTFS as pathtype to access locked files, used for e.g. registry files, now also via command line.
* Update CHANGELOG to reflect those changes.