### PR TITLE
Fix regex handling in Get-FlowArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/swisscom/powergrr/compare/v0.12.0...master)
 
+### Fixed
+* Fix regex handling in method `Get-FlowArgs` by using base64 for regex
 <!--
 ### Added
 ### Changed
-### Fixed
 ### Security
 ### Deprecated
 ### Removed

--- a/PowerGRR.psm1
+++ b/PowerGRR.psm1
@@ -1247,7 +1247,7 @@ function Get-FlowArgs()
                 throw "Please provide a regex search string with -SearchString."
             }
             $PluginArguments += ',"conditions":[{"condition_type":"CONTENTS_REGEX_MATCH",'
-            $PluginArguments += '"contents_regex_match":{"regex":"'+$($Parameters['SearchString'])+'","mode":"'+$RegexMode+'"}}]}'
+            $PluginArguments += '"contents_regex_match":{"regex":"'+$($Parameters['SearchString'] | ConvertTo-Base64 )+'","mode":"'+$RegexMode+'"}}]}'
         }
         elseif ($Parameters['ConditionType'] -match "literal")
         {

--- a/PowerGRR.psm1
+++ b/PowerGRR.psm1
@@ -1286,7 +1286,7 @@ function Get-FlowArgs()
                 throw "Please provide a regex condition string with -ConditionString."
             }
             $PluginArguments += ',"conditions":[{"condition_type":"VALUE_REGEX_MATCH",'
-            $PluginArguments += '"value_regex_match":{"regex":"'+$($Parameters['ConditionString'])+'","mode":"'+$RegexMode+'"}}]}'
+            $PluginArguments += '"value_regex_match":{"regex":"'+$($Parameters['ConditionString'] | ConvertTo-Base64 )+'","mode":"'+$RegexMode+'"}}]}'
         }
         elseif ($Parameters['ConditionType'] -match "literal")
         {


### PR DESCRIPTION
* Fix regex handling in `Get-FlowArgs` by using base64 for regex value.
* Update changelog to reflect those changes